### PR TITLE
Analytics improvements

### DIFF
--- a/changelogs/whatsnew-en-GB
+++ b/changelogs/whatsnew-en-GB
@@ -1,3 +1,4 @@
 Changes & Fixes:
 Reworked the underlying watch connection interface
+Made some improvements to the way analytics events are logged
 You should see stability improvements over the next few releases

--- a/mobile/src/main/java/com/boswelja/devicemanager/analytics/Analytics.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/analytics/Analytics.kt
@@ -1,75 +1,71 @@
 package com.boswelja.devicemanager.analytics
 
-import android.content.Context
-import android.content.SharedPreferences
-import androidx.preference.PreferenceManager
-import com.boswelja.devicemanager.common.preference.SyncPreferences
 import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
+import com.google.firebase.ktx.Firebase
 
-class Analytics {
+/**
+ * Wrapper for [FirebaseAnalytics] to simplify logging analytics events.
+ */
+class Analytics constructor(private val firebaseAnalytics: FirebaseAnalytics = Firebase.analytics) {
 
-    private val sharedPreferences: SharedPreferences
-    private val firebaseAnalytics: FirebaseAnalytics
-
-    internal constructor(
-        firebaseAnalytics: FirebaseAnalytics,
-        sharedPreferences: SharedPreferences
-    ) {
-        this.sharedPreferences = sharedPreferences
-        this.firebaseAnalytics = firebaseAnalytics
+    /**
+     * Set whether analytics collection is enabled.
+     */
+    fun setAnalyticsEnabled(isEnabled: Boolean) {
+        firebaseAnalytics.setAnalyticsCollectionEnabled(isEnabled)
     }
 
-    constructor(context: Context) {
-        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-        firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-    }
-
-    fun logSettingChanged(key: String, value: Any) {
-        if (sharedPreferences.getBoolean(ANALYTICS_ENABLED_KEY, false)) {
-            if (key in SyncPreferences.ALL_PREFS) {
-                logExtensionSettingChanged(key, value)
-            } else {
-                logAppSettingChanged(key, value)
-            }
-        }
-    }
-
+    /**
+     * Log an extension setting change.
+     * @param key The key for the preference that was changed.
+     * @param value The value of the changed preference.
+     */
     fun logExtensionSettingChanged(key: String, value: Any) {
-        if (sharedPreferences.getBoolean(ANALYTICS_ENABLED_KEY, false)) {
-            firebaseAnalytics.logEvent(EVENT_EXTENSION_SETTING_CHANGED) {
-                param(FirebaseAnalytics.Param.ITEM_ID, key)
-                param(FirebaseAnalytics.Param.VALUE, value.toString())
-            }
+        firebaseAnalytics.logEvent(EVENT_EXTENSION_SETTING_CHANGED) {
+            param(FirebaseAnalytics.Param.ITEM_ID, key)
+            param(FirebaseAnalytics.Param.VALUE, value.toString())
         }
     }
 
-    fun logAppSettingChanged(key: String, value: Any) {
-        if (sharedPreferences.getBoolean(ANALYTICS_ENABLED_KEY, false)) {
-            firebaseAnalytics.logEvent(EVENT_APP_SETTING_CHANGED) {
-                param(FirebaseAnalytics.Param.ITEM_ID, key)
-                param(FirebaseAnalytics.Param.VALUE, value.toString())
-            }
+    /**
+     * Log an app setting change.
+     * @param key The key for the preference that was changed.
+     */
+    fun logAppSettingChanged(key: String) {
+        firebaseAnalytics.logEvent(EVENT_APP_SETTING_CHANGED) {
+            param(FirebaseAnalytics.Param.ITEM_ID, key)
         }
     }
 
+    /**
+     * Log a new watch being registered.
+     */
     fun logWatchRegistered() {
-        if (sharedPreferences.getBoolean(ANALYTICS_ENABLED_KEY, false)) {
-            firebaseAnalytics.logEvent(EVENT_WATCH_REGISTERED, null)
-        }
+        firebaseAnalytics.logEvent(EVENT_WATCH_REGISTERED, null)
     }
 
+    /**
+     * Log an existing watch being removed.
+     */
     fun logWatchRemoved() {
-        if (sharedPreferences.getBoolean(ANALYTICS_ENABLED_KEY, false)) {
-            firebaseAnalytics.logEvent(EVENT_WATCH_REMOVED, null)
-        }
+        firebaseAnalytics.logEvent(EVENT_WATCH_REMOVED, null)
     }
 
+    /**
+     * Log a watch being renamed.
+     */
+    fun logWatchRenamed() {
+        firebaseAnalytics.logEvent(EVENT_WATCH_RENAMED, null)
+    }
+
+    /**
+     * Log an action being performed in StorageManager.
+     */
     fun logStorageManagerAction(action: String) {
-        if (sharedPreferences.getBoolean(ANALYTICS_ENABLED_KEY, false)) {
-            firebaseAnalytics.logEvent(EVENT_STORAGE_MANAGER) {
-                param(FirebaseAnalytics.Param.METHOD, action)
-            }
+        firebaseAnalytics.logEvent(EVENT_STORAGE_MANAGER) {
+            param(FirebaseAnalytics.Param.METHOD, action)
         }
     }
 
@@ -80,6 +76,7 @@ class Analytics {
         internal const val EVENT_APP_SETTING_CHANGED = "app_setting_changed"
         internal const val EVENT_WATCH_REGISTERED = "watch_registered"
         internal const val EVENT_WATCH_REMOVED = "watch_registered"
+        internal const val EVENT_WATCH_RENAMED = "watch_renamed"
         internal const val EVENT_STORAGE_MANAGER = "storage_manager"
     }
 }

--- a/mobile/src/main/java/com/boswelja/devicemanager/appsettings/ui/AppSettingsFragment.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/appsettings/ui/AppSettingsFragment.kt
@@ -8,6 +8,7 @@
 package com.boswelja.devicemanager.appsettings.ui
 
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -15,15 +16,32 @@ import androidx.navigation.fragment.findNavController
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import com.boswelja.devicemanager.R
+import com.boswelja.devicemanager.analytics.Analytics
 import com.boswelja.devicemanager.common.Compat
 import com.boswelja.devicemanager.common.ui.BaseDayNightActivity.Companion.DAYNIGHT_MODE_KEY
 import com.boswelja.devicemanager.common.ui.BasePreferenceFragment
 import timber.log.Timber
 
-class AppSettingsFragment : BasePreferenceFragment(), Preference.OnPreferenceClickListener {
+class AppSettingsFragment :
+    BasePreferenceFragment(),
+    Preference.OnPreferenceClickListener,
+    SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private val analytics = Analytics()
 
     private lateinit var openNotiSettingsPreference: Preference
     private lateinit var daynightModePreference: ListPreference
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        if (key != null) {
+            when (key) {
+                Analytics.ANALYTICS_ENABLED_KEY -> {
+                    analytics.setAnalyticsEnabled(sharedPreferences!!.getBoolean(key, false))
+                }
+                else -> analytics.logAppSettingChanged(key)
+            }
+        }
+    }
 
     override fun onPreferenceClick(preference: Preference?): Boolean {
         return when (preference?.key) {

--- a/mobile/src/main/java/com/boswelja/devicemanager/managespace/ManageSpaceActivity.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/managespace/ManageSpaceActivity.kt
@@ -39,7 +39,7 @@ class ManageSpaceActivity : BaseToolbarActivity() {
     private lateinit var binding: ActivityManageSpaceBinding
     private lateinit var activityManager: ActivityManager
 
-    private val analytics: Analytics by lazy { Analytics(this) }
+    private val analytics: Analytics by lazy { Analytics() }
     private val watchManager: WatchManager by lazy { WatchManager.getInstance(this) }
     private var hasResetApp = false
 

--- a/mobile/src/main/java/com/boswelja/devicemanager/watchmanager/WatchManager.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/watchmanager/WatchManager.kt
@@ -38,7 +38,7 @@ class WatchManager internal constructor(
     constructor(context: Context) : this(
         PreferenceManager.getDefaultSharedPreferences(context),
         WatchRepository(context),
-        Analytics(context),
+        Analytics(),
         CoroutineScope(Dispatchers.IO)
     )
 
@@ -117,6 +117,7 @@ class WatchManager internal constructor(
 
     suspend fun renameWatch(watch: Watch, newName: String) {
         watchRepository.renameWatch(watch, newName)
+        analytics.logWatchRenamed()
     }
 
     suspend fun requestResetWatch(watch: Watch) {
@@ -138,8 +139,10 @@ class WatchManager internal constructor(
     suspend inline fun <reified T> getPreference(watch: Watch, key: String) =
         watchRepository.getPreference<T>(watch, key)
 
-    suspend fun updatePreference(watch: Watch, key: String, value: Any) =
+    suspend fun updatePreference(watch: Watch, key: String, value: Any) {
         watchRepository.updatePreference(watch, key, value)
+        analytics.logExtensionSettingChanged(key, value)
+    }
 
     companion object : SingletonHolder<WatchManager, Context>(::WatchManager) {
         const val LAST_SELECTED_NODE_ID_KEY = "last_connected_id"

--- a/mobile/src/test/java/com/boswelja/devicemanager/watchmanager/WatchManagerTest.kt
+++ b/mobile/src/test/java/com/boswelja/devicemanager/watchmanager/WatchManagerTest.kt
@@ -129,10 +129,11 @@ class WatchManagerTest {
     }
 
     @Test
-    fun `renameWatch calls repository`(): Unit = runBlocking {
+    fun `renameWatch calls repository and logs analytics event`(): Unit = runBlocking {
         val newName = "dummy name"
         watchManager = getWatchManager()
         watchManager.renameWatch(dummyWatch1, newName)
+        verify(exactly = 1) { analytics.logWatchRenamed() }
         coVerify(exactly = 1) { repository.renameWatch(dummyWatch1, newName) }
     }
 


### PR DESCRIPTION
Add a bit more logging, and improve enabling/disabling analytics.
Calls to log* functions should be a bit faster, as we don't check sharedPreferences anymore. We instead make use of FirebaseAnalytics built-in setAnalyticsCollectionEnabled.
Resolves #71 