### PR TITLE
Remove MY_PACKAGE_REPLACED receiver from Wear OS module

### DIFF
--- a/mobile/src/main/java/com/boswelja/devicemanager/watchinfo/ui/WatchInfoActivity.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/watchinfo/ui/WatchInfoActivity.kt
@@ -60,6 +60,10 @@ class WatchInfoActivity : BaseToolbarActivity() {
     }
 
     private fun setupButtons() {
+        binding.refreshCapabilitiesButton.setOnClickListener {
+            viewModel.refreshCapabilities()
+            createSnackBar(getString(R.string.refresh_capabilities_requested))
+        }
         binding.clearPreferencesButton.setOnClickListener {
             clearPreferencesSheet.show(
                 supportFragmentManager,

--- a/mobile/src/main/java/com/boswelja/devicemanager/watchinfo/ui/WatchInfoViewModel.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/watchinfo/ui/WatchInfoViewModel.kt
@@ -69,6 +69,12 @@ class WatchInfoViewModel internal constructor(
         }
     }
 
+    fun refreshCapabilities() {
+        _watch.value?.let {
+            watchManager.requestRefreshCapabilities(it)
+        }
+    }
+
     /**
      * Forgets the current watch.
      */

--- a/mobile/src/main/java/com/boswelja/devicemanager/watchmanager/WatchManager.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/watchmanager/WatchManager.kt
@@ -141,6 +141,10 @@ class WatchManager internal constructor(
         _selectedWatchId.postValue(watchId)
     }
 
+    fun requestRefreshCapabilities(watch: Watch) {
+        watchRepository.requestRefreshCapabilities(watch)
+    }
+
     fun refreshData() = watchRepository.refreshData()
 
     suspend inline fun <reified T> getPreference(watch: Watch, key: String) =

--- a/mobile/src/main/java/com/boswelja/devicemanager/watchmanager/WatchRepository.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/watchmanager/WatchRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import com.boswelja.devicemanager.common.connection.Messages
 import com.boswelja.devicemanager.common.preference.SyncPreferences
 import com.boswelja.devicemanager.common.setup.References
 import com.boswelja.devicemanager.watchmanager.connection.WatchConnectionInterface
@@ -221,6 +222,14 @@ class WatchRepository internal constructor(
         connectionManagers.values.forEach {
             it.refreshData()
         }
+    }
+
+    /**
+     * Sends [Messages.REQUEST_UPDATE_CAPABILITIES] to a given [Watch].
+     * @param watch The [Watch] to request capabilities be updated for.
+     */
+    fun requestRefreshCapabilities(watch: Watch) {
+        watch.connectionManager?.sendMessage(watch.id, Messages.REQUEST_UPDATE_CAPABILITIES)
     }
 
     /**

--- a/mobile/src/main/res/layout/activity_watch_info.xml
+++ b/mobile/src/main/res/layout/activity_watch_info.xml
@@ -63,6 +63,17 @@
                 tools:itemCount="5" />
 
             <com.google.android.material.button.MaterialButton
+                android:id="@+id/refresh_capabilities_button"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/watch_info_section_vertical_margin"
+                android:text="@string/refresh_capabilities"
+                android:layout_gravity="center_horizontal"
+                app:icon="@drawable/ic_refresh"
+                app:iconGravity="start" />
+
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/clear_preferences_button"
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
                 android:layout_width="wrap_content"

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -163,6 +163,8 @@
     <string name="forget_watch_dialog_title">@string/button_forget_watch</string>
     <string name="forget_watch_dialog_message">Are you sure you want to forget your %s? This will clear all Wearable Extensions settings, and remove your %s from the app.</string>
     <string name="capabilities_title">On this watch, Wearable Extensions can:</string>
+    <string name="refresh_capabilities">Refresh Capabilities</string>
+    <string name="refresh_capabilities_requested">Requested this watch update it\'s capabilities</string>
 
     <!-- Watch Manager strings -->
     <string name="watch_manager_title">Watch Manager</string>

--- a/mobile/src/test/java/com/boswelja/devicemanager/watchinfo/ui/WatchInfoViewModelTest.kt
+++ b/mobile/src/test/java/com/boswelja/devicemanager/watchinfo/ui/WatchInfoViewModelTest.kt
@@ -85,6 +85,19 @@ class WatchInfoViewModelTest {
     }
 
     @Test
+    fun `refreshCapabilities calls watchManager if watch is not null`() {
+        // Check with no / invalid watch selected
+        viewModel.refreshCapabilities()
+        coVerify(inverse = true) { watchManager.requestRefreshCapabilities(any()) }
+
+        // Check with valid watch selected
+        viewModel.setWatch(dummyWatch.id)
+        viewModel.watch.getOrAwaitValue()
+        viewModel.refreshCapabilities()
+        coVerify { watchManager.requestRefreshCapabilities(dummyWatch) }
+    }
+
+    @Test
     fun `forgetWatch calls watchManager if watch is not null`() {
         // Check with no / invalid watch selected
         viewModel.forgetWatch()

--- a/mobile/src/test/java/com/boswelja/devicemanager/watchmanager/WatchManagerTest.kt
+++ b/mobile/src/test/java/com/boswelja/devicemanager/watchmanager/WatchManagerTest.kt
@@ -115,6 +115,13 @@ class WatchManagerTest {
     }
 
     @Test
+    fun `requestRefreshCapabilities calls repository`(): Unit = runBlocking {
+        watchManager = getWatchManager()
+        watchManager.requestRefreshCapabilities(dummyWatch1)
+        coVerify(exactly = 1) { repository.requestRefreshCapabilities(dummyWatch1) }
+    }
+
+    @Test
     fun `registerWatch calls repository and logs analytics event`(): Unit = runBlocking {
         watchManager = getWatchManager()
         watchManager.registerWatch(dummyWatch1)

--- a/wearos/src/main/AndroidManifest.xml
+++ b/wearos/src/main/AndroidManifest.xml
@@ -160,11 +160,10 @@
             android:exported="false" />
 
         <receiver
-            android:name=".BootOrUpdateReceiver"
+            android:name=".BootReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
-                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/wearos/src/main/java/com/boswelja/devicemanager/BootReceiver.kt
+++ b/wearos/src/main/java/com/boswelja/devicemanager/BootReceiver.kt
@@ -18,13 +18,13 @@ import com.boswelja.devicemanager.common.preference.PreferenceKey.DND_SYNC_WITH_
 import com.boswelja.devicemanager.dndsync.DnDLocalChangeListener
 import timber.log.Timber
 
-class BootOrUpdateReceiver : BroadcastReceiver() {
+class BootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         Timber.d("Intent received")
         when (intent?.action) {
-            Intent.ACTION_MY_PACKAGE_REPLACED, Intent.ACTION_BOOT_COMPLETED -> {
-                Timber.d("Boot or update, handling")
+            Intent.ACTION_BOOT_COMPLETED -> {
+                Timber.d("Handling ${intent.action}")
                 CapabilityUpdater(context!!).updateCapabilities()
                 val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
                 if (sharedPreferences.getBoolean(DND_SYNC_TO_PHONE_KEY, false) ||

--- a/wearos/src/main/java/com/boswelja/devicemanager/main/ui/MainViewModel.kt
+++ b/wearos/src/main/java/com/boswelja/devicemanager/main/ui/MainViewModel.kt
@@ -9,8 +9,12 @@ package com.boswelja.devicemanager.main.ui
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
+import com.boswelja.devicemanager.capability.CapabilityUpdater
 import com.boswelja.devicemanager.phoneconnectionmanager.References.PHONE_ID_KEY
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -18,4 +22,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     val isRegistered: Boolean
         get() = !sharedPreferences.getString(PHONE_ID_KEY, "").isNullOrBlank()
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            CapabilityUpdater(application).updateCapabilities()
+        }
+    }
 }


### PR DESCRIPTION
Resolves #96 
Since we seemingly can't receive MY_PACKAGE_REPLACED on Wear OS, I've removed the related code.
CapabilityUpdater essentially relies on this, the best workaround I could come up with was to update capabilities on app launch instead, and add a button to the mobile app to manually refresh capabilities.