### PR TITLE
Fix Wear OS advertising capabilities it doesn't actually have

### DIFF
--- a/wearos/src/main/java/com/boswelja/devicemanager/capability/CapabilityUpdater.kt
+++ b/wearos/src/main/java/com/boswelja/devicemanager/capability/CapabilityUpdater.kt
@@ -77,7 +77,7 @@ class CapabilityUpdater(
         }
     }
 
-    private fun canQueryAllPackages(): Boolean {
+    internal fun canQueryAllPackages(): Boolean {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             context.checkSelfPermission(Manifest.permission.QUERY_ALL_PACKAGES) ==
                 PackageManager.PERMISSION_GRANTED
@@ -86,7 +86,7 @@ class CapabilityUpdater(
         }
     }
 
-    private fun hasNotiPolicyAccess(): Boolean {
+    internal fun hasNotiPolicyAccess(): Boolean {
         return context.getSystemService<NotificationManager>()
             ?.isNotificationPolicyAccessGranted == true
     }

--- a/wearos/src/main/java/com/boswelja/devicemanager/capability/CapabilityUpdater.kt
+++ b/wearos/src/main/java/com/boswelja/devicemanager/capability/CapabilityUpdater.kt
@@ -1,13 +1,14 @@
 package com.boswelja.devicemanager.capability
 
 import android.Manifest
+import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.content.getSystemService
 import com.boswelja.devicemanager.common.connection.Capability
 import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.Wearable
-import java.util.EnumSet
 import timber.log.Timber
 
 /**
@@ -32,7 +33,6 @@ class CapabilityUpdater(
         updateReceiveDnD()
         updateSendBattery()
         updateManageApps()
-        EnumSet.of(Capability.SEND_DND, Capability.SYNC_BATTERY)
     }
 
     /**
@@ -49,9 +49,7 @@ class CapabilityUpdater(
     internal fun updateReceiveDnD() {
         // Either the watch is capable of granting ACCESS_NOTIFICATION_POLICY (via older SDKs), or
         // it's already granted.
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O ||
-            hasPermission(Manifest.permission.ACCESS_NOTIFICATION_POLICY)
-        ) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O || hasNotiPolicyAccess()) {
             capabilityClient.addLocalCapability(Capability.RECEIVE_DND.name)
         } else {
             capabilityClient.removeLocalCapability(Capability.RECEIVE_DND.name)
@@ -72,16 +70,24 @@ class CapabilityUpdater(
     internal fun updateManageApps() {
         // QUERY_ALL_APPS should be granted automatically upon app install, so we only check if it's
         // been granted.
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q ||
-            hasPermission(Manifest.permission.QUERY_ALL_PACKAGES)
-        ) {
+        if (canQueryAllPackages()) {
             capabilityClient.addLocalCapability(Capability.MANAGE_APPS.name)
         } else {
             capabilityClient.removeLocalCapability(Capability.MANAGE_APPS.name)
         }
     }
 
-    internal fun hasPermission(permission: String): Boolean {
-        return context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+    private fun canQueryAllPackages(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            context.checkSelfPermission(Manifest.permission.QUERY_ALL_PACKAGES) ==
+                PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
+    private fun hasNotiPolicyAccess(): Boolean {
+        return context.getSystemService<NotificationManager>()
+            ?.isNotificationPolicyAccessGranted == true
     }
 }

--- a/wearos/src/test/java/com/boswelja/devicemanager/capability/CapabilityUpdaterTest.kt
+++ b/wearos/src/test/java/com/boswelja/devicemanager/capability/CapabilityUpdaterTest.kt
@@ -1,7 +1,5 @@
 package com.boswelja.devicemanager.capability
 
-import android.Manifest.permission.ACCESS_NOTIFICATION_POLICY
-import android.Manifest.permission.QUERY_ALL_PACKAGES
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -59,12 +57,12 @@ class CapabilityUpdaterTest {
             verify(exactly = 1) { capabilityClient.addLocalCapability(RECEIVE_DND.name) }
         } else {
             // Emulate permission granted
-            every { capabilityUpdater.hasPermission(ACCESS_NOTIFICATION_POLICY) } returns true
+            every { capabilityUpdater.hasNotiPolicyAccess() } returns true
             capabilityUpdater.updateReceiveDnD()
             verify(exactly = 1) { capabilityClient.addLocalCapability(RECEIVE_DND.name) }
 
             // Emulate permission denied
-            every { capabilityUpdater.hasPermission(ACCESS_NOTIFICATION_POLICY) } returns false
+            every { capabilityUpdater.hasNotiPolicyAccess() } returns false
             capabilityUpdater.updateReceiveDnD()
             verify(exactly = 1) { capabilityClient.removeLocalCapability(RECEIVE_DND.name) }
         }
@@ -78,12 +76,12 @@ class CapabilityUpdaterTest {
             verify(exactly = 1) { capabilityClient.addLocalCapability(MANAGE_APPS.name) }
         } else {
             // Emulate permission granted
-            every { capabilityUpdater.hasPermission(QUERY_ALL_PACKAGES) } returns true
+            every { capabilityUpdater.canQueryAllPackages() } returns true
             capabilityUpdater.updateManageApps()
             verify(exactly = 1) { capabilityClient.addLocalCapability(MANAGE_APPS.name) }
 
             // Emulate permission denied
-            every { capabilityUpdater.hasPermission(QUERY_ALL_PACKAGES) } returns false
+            every { capabilityUpdater.canQueryAllPackages() } returns false
             capabilityUpdater.updateManageApps()
             verify(exactly = 1) { capabilityClient.removeLocalCapability(MANAGE_APPS.name) }
         }


### PR DESCRIPTION
Seems like calling checkSelfPermission with ACCESS_NOTIFICATION_POLICY returns true whether we have the permission or not. Fortunately isNotiPolicyAccessGranted is a reliable way of checking the same permission.
Also made some minor improvements to QUERY_ALL_PACKAGES checking.
Resolves #102 