### PR TITLE
Wear OS connection fixes

### DIFF
--- a/common/src/main/java/com/boswelja/devicemanager/common/batterysync/BatteryStats.kt
+++ b/common/src/main/java/com/boswelja/devicemanager/common/batterysync/BatteryStats.kt
@@ -1,19 +1,57 @@
 package com.boswelja.devicemanager.common.batterysync
 
-import com.google.android.gms.wearable.MessageEvent
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
 
-open class BatteryStats(
-    open val percent: Int,
-    open val isCharging: Boolean,
-    open val lastUpdatedMillis: Long = System.currentTimeMillis()
+/**
+ * A data class containing information related to a device's battery.
+ * @param percent The device's battery percent.
+ * @param isCharging true if the device is charging, false otherwise.
+ * @param lastUpdatedMillis The time in milliseconds this data was fetched.
+ */
+data class BatteryStats internal constructor(
+    val percent: Int,
+    val isCharging: Boolean,
+    val lastUpdatedMillis: Long = System.currentTimeMillis()
 ) {
+
+    /**
+     * Convert this [BatteryStats] to a [ByteArray].
+     */
+    fun toByteArray(): ByteArray {
+        return "$percent|$isCharging".toByteArray(Charsets.UTF_8)
+    }
+
     companion object {
-        fun fromMessage(messageEvent: MessageEvent): BatteryStats {
-            val message = String(messageEvent.data, Charsets.UTF_8)
+        /**
+         * Get a [BatteryStats] from a [ByteArray].
+         */
+        fun fromByteArray(byteArray: ByteArray): BatteryStats {
+            val message = String(byteArray, Charsets.UTF_8)
             val messageSplit = message.split("|")
             val batteryPercent = messageSplit[0].toInt()
             val isWatchCharging = messageSplit[1] == true.toString()
             return BatteryStats(batteryPercent, isWatchCharging)
+        }
+
+        /**
+         * Get an up to date [BatteryStats] for this device.
+         * @param context [Context].
+         * @return The [BatteryStats] for this device, or null if there was an issue.
+         */
+        fun createForDevice(context: Context): BatteryStats? {
+            val iFilter = IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+            context.registerReceiver(null, iFilter)?.let {
+                val batteryLevel = it.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+                val batteryScale = it.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+                val percent = (batteryLevel * 100) / batteryScale
+                val charging = it.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ==
+                    BatteryManager.BATTERY_STATUS_CHARGING
+                return BatteryStats(percent, charging)
+            }
+            return null
         }
     }
 }

--- a/mobile/src/main/java/com/boswelja/devicemanager/batterysync/database/WatchBatteryStats.kt
+++ b/mobile/src/main/java/com/boswelja/devicemanager/batterysync/database/WatchBatteryStats.kt
@@ -26,7 +26,7 @@ data class WatchBatteryStats(
     companion object {
         fun fromMessage(messageEvent: MessageEvent): WatchBatteryStats {
             val watchId = messageEvent.sourceNodeId
-            val batteryStats = BatteryStats.fromMessage(messageEvent)
+            val batteryStats = BatteryStats.fromByteArray(messageEvent.data)
             return WatchBatteryStats(watchId, batteryStats.percent, batteryStats.isCharging)
         }
     }

--- a/wearos/src/main/java/com/boswelja/devicemanager/ActionService.kt
+++ b/wearos/src/main/java/com/boswelja/devicemanager/ActionService.kt
@@ -1,10 +1,3 @@
-/* Copyright (C) 2020 Jack Boswell <boswelja@outlook.com>
- *
- * This file is part of Wearable Extensions
- *
- * This file, and any part of the Wearable Extensions app/s cannot be copied and/or distributed
- * without permission from Jack Boswell (boswelja) <boswela@outlook.com>
- */
 package com.boswelja.devicemanager
 
 import android.content.BroadcastReceiver
@@ -14,29 +7,21 @@ import androidx.core.app.JobIntentService
 import androidx.preference.PreferenceManager
 import com.boswelja.devicemanager.common.batterysync.References.REQUEST_BATTERY_UPDATE_PATH
 import com.boswelja.devicemanager.common.connection.Messages.LOCK_PHONE
-import com.boswelja.devicemanager.common.preference.PreferenceKey
 import com.boswelja.devicemanager.common.preference.PreferenceKey.BATTERY_SYNC_ENABLED_KEY
+import com.boswelja.devicemanager.common.preference.PreferenceKey.PHONE_LOCKING_ENABLED_KEY
 import com.boswelja.devicemanager.phoneconnectionmanager.References.PHONE_ID_KEY
 import com.google.android.gms.wearable.Wearable
 import timber.log.Timber
 
 class ActionService : JobIntentService() {
 
-    private val messageClient by lazy { Wearable.getMessageClient(this) }
-    private val sharedPreferences by lazy { PreferenceManager.getDefaultSharedPreferences(this) }
-    private val phoneId by lazy { sharedPreferences.getString(PHONE_ID_KEY, "") ?: "" }
-
     override fun onHandleWork(intent: Intent) {
         Timber.d("onHandleWork($intent) called")
-        if (phoneId.isNotEmpty()) {
-            when (
-                val action = intent.action
-            ) {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+        sharedPreferences.getString(PHONE_ID_KEY, "")?.let { phoneId ->
+            when (val action = intent.action) {
                 LOCK_PHONE -> {
-                    if (sharedPreferences.getBoolean(
-                            PreferenceKey.PHONE_LOCKING_ENABLED_KEY, false
-                        )
-                    ) {
+                    if (sharedPreferences.getBoolean(PHONE_LOCKING_ENABLED_KEY, false)) {
                         sendMessage(
                             phoneId,
                             action,
@@ -65,7 +50,7 @@ class ActionService : JobIntentService() {
         successMessage: String,
         failMessage: String
     ) {
-        messageClient
+        Wearable.getMessageClient(this)
             .sendMessage(nodeId, action, null)
             .addOnSuccessListener {
                 ConfirmationActivityHandler.successAnimation(this, successMessage)

--- a/wearos/src/main/java/com/boswelja/devicemanager/extensions/ui/ExtensionsViewModel.kt
+++ b/wearos/src/main/java/com/boswelja/devicemanager/extensions/ui/ExtensionsViewModel.kt
@@ -116,7 +116,10 @@ class ExtensionsViewModel internal constructor(
                 getApplication<Application>().getString(R.string.battery_sync_disabled)
             )
         } else {
-            ConfirmationActivityHandler.failAnimation(getApplication())
+            ConfirmationActivityHandler.failAnimation(
+                getApplication(),
+                getApplication<Application>().getString(R.string.phone_not_connected)
+            )
         }
     }
 
@@ -132,7 +135,10 @@ class ExtensionsViewModel internal constructor(
                 getApplication<Application>().getString(R.string.lock_phone_disabled)
             )
         } else {
-            ConfirmationActivityHandler.failAnimation(getApplication())
+            ConfirmationActivityHandler.failAnimation(
+                getApplication(),
+                getApplication<Application>().getString(R.string.phone_not_connected)
+            )
         }
     }
 }

--- a/wearos/src/main/java/com/boswelja/devicemanager/main/ui/MainActivity.kt
+++ b/wearos/src/main/java/com/boswelja/devicemanager/main/ui/MainActivity.kt
@@ -20,7 +20,7 @@ class MainActivity : AppCompatActivity() {
             val viewModel: MainViewModel = viewModel()
             val isRegistered by viewModel.isRegistered.observeAsState()
             AppTheme {
-                if (isRegistered == false) {
+                if (isRegistered == true) {
                     ExtensionsScreen()
                 } else {
                     OnboardingScreen()

--- a/wearos/src/main/java/com/boswelja/devicemanager/main/ui/MainViewModel.kt
+++ b/wearos/src/main/java/com/boswelja/devicemanager/main/ui/MainViewModel.kt
@@ -5,24 +5,18 @@ import android.content.SharedPreferences
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
 import com.boswelja.devicemanager.capability.CapabilityUpdater
 import com.boswelja.devicemanager.phoneconnectionmanager.References.PHONE_ID_KEY
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class MainViewModel internal constructor(
     application: Application,
-    coroutineDispatcher: CoroutineDispatcher,
     private val sharedPreferences: SharedPreferences
 ) : AndroidViewModel(application) {
 
     @Suppress("unused")
     constructor(application: Application) : this(
         application,
-        Dispatchers.IO,
         PreferenceManager.getDefaultSharedPreferences(application)
     )
 
@@ -43,9 +37,7 @@ class MainViewModel internal constructor(
 
     init {
         sharedPreferences.registerOnSharedPreferenceChangeListener(registrationObserver)
-        viewModelScope.launch(coroutineDispatcher) {
-            CapabilityUpdater(application).updateCapabilities()
-        }
+        CapabilityUpdater(application).updateCapabilities()
     }
 
     override fun onCleared() {

--- a/wearos/src/main/res/values/strings.xml
+++ b/wearos/src/main/res/values/strings.xml
@@ -43,4 +43,5 @@
 
     <string name="error">An error has occurred</string>
     <string name="default_phone_name">Phone</string>
+    <string name="phone_not_connected">Can\'t connect to your phone</string>
 </resources>

--- a/wearos/src/test/java/com/boswelja/devicemanager/main/ui/MainViewModelTest.kt
+++ b/wearos/src/test/java/com/boswelja/devicemanager/main/ui/MainViewModelTest.kt
@@ -1,0 +1,78 @@
+package com.boswelja.devicemanager.main.ui
+
+import android.content.SharedPreferences
+import android.os.Build
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.boswelja.devicemanager.capability.CapabilityUpdater
+import com.boswelja.devicemanager.getOrAwaitValue
+import com.boswelja.devicemanager.phoneconnectionmanager.References.PHONE_ID_KEY
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockkConstructor
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+@ExperimentalCoroutinesApi
+class MainViewModelTest {
+
+    @get:Rule
+    val taskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var sharedPreferences: SharedPreferences
+
+    @Before
+    fun setUp() {
+        mockkConstructor(CapabilityUpdater::class)
+        every { anyConstructed<CapabilityUpdater>().updateCapabilities() } answers { }
+
+        sharedPreferences = PreferenceManager
+            .getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun `isRegistered correctly updates on ViewModel init`() {
+        // Check with a 'valid' ID
+        sharedPreferences.edit(commit = true) { putString(PHONE_ID_KEY, "id") }
+        var viewModel = getViewModel()
+        assertThat(viewModel.isRegistered.getOrAwaitValue()).isTrue()
+
+        // Check with no ID
+        sharedPreferences.edit(commit = true) { putString(PHONE_ID_KEY, "") }
+        viewModel = getViewModel()
+        assertThat(viewModel.isRegistered.getOrAwaitValue()).isFalse()
+    }
+
+    @Test
+    fun `isRegistered correctly updates after ViewModel init`() {
+        val viewModel = getViewModel()
+
+        // Check with a 'valid' ID
+        sharedPreferences.edit(commit = true) { putString(PHONE_ID_KEY, "id") }
+        assertThat(viewModel.isRegistered.getOrAwaitValue()).isTrue()
+
+        // Check with no ID
+        sharedPreferences.edit(commit = true) { putString(PHONE_ID_KEY, "") }
+        assertThat(viewModel.isRegistered.getOrAwaitValue()).isFalse()
+    }
+
+    @Test
+    fun `Capabilities are updated on ViewModel init`() {
+        getViewModel()
+        verify(exactly = 1) { anyConstructed<CapabilityUpdater>().updateCapabilities() }
+    }
+    private fun getViewModel(): MainViewModel = MainViewModel(
+        ApplicationProvider.getApplicationContext(),
+        sharedPreferences
+    )
+}


### PR DESCRIPTION
There was a bug present where the app would allow users to reach ExtensionsScreen without registering a phone, which appeared to the user as everything reporting phone not connected.
Clarified issues when the phone actually isn't connected.
Made some improvements to Battery Sync under the hood to help improve reliability.
Indirectly resolves #130 and #129